### PR TITLE
ensure that CI runs on Ubuntu 16.04

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     services:
       db:

--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     services:
       db:

--- a/.github/workflows/ex_check.yml
+++ b/.github/workflows/ex_check.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     services:
       db:

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2723,9 +2723,9 @@
       }
     },
     "css-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.3.2.tgz",
-      "integrity": "sha512-4XSiURS+YEK2fQhmSaM1onnUm0VKWNf6WWBYjkp9YbSDGCBTVZ5XOM6Gkxo8tLgQlzkZOBJvk9trHlDk4gjEYg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.0.tgz",
+      "integrity": "sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
@@ -2733,13 +2733,13 @@
         "icss-utils": "^4.1.1",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.23",
+        "postcss": "^7.0.17",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
-        "postcss-modules-scope": "^2.1.1",
+        "postcss-modules-scope": "^2.1.0",
         "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.0.2",
-        "schema-utils": "^2.6.0"
+        "postcss-value-parser": "^4.0.0",
+        "schema-utils": "^2.0.0"
       },
       "dependencies": {
         "schema-utils": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,7 +19,7 @@
     "babel-loader": "^8.0.0",
     "babel-minify-webpack-plugin": "^0.3.1",
     "copy-webpack-plugin": "^5.1.1",
-    "css-loader": "3.3.2",
+    "css-loader": "3.2.0",
     "cypress": "^3.8.3",
     "expose-loader": "^0.7.5",
     "mini-css-extract-plugin": "^0.9.0",


### PR DESCRIPTION
Github recently upgraded their CI from Ubuntu 16.04 to 18.04 and it has made Cypress a bit flakey.