### PR TITLE
Update Dependabot config.yml

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,4 +9,8 @@ update_configs:
     directory: "/assets"
     update_schedule: "weekly"
     automerged_updates:
-    - match: {dependency_type: "all", update_type: "semver:patch"}
+    - match: {dependency_type: "all", update_type: "all"}
+    ignored_updates:
+    - match:
+        dependency_name: "css-loader"
+        version_requirement: "3.2.*"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,6 @@ update_configs:
     - match: {dependency_type: "all", update_type: "all"}
   - package_manager: "javascript"
     directory: "/assets"
-    update_schedule: "live"
+    update_schedule: "weekly"
     automerged_updates:
-    - match: {dependency_type: "all", update_type: "all"}
+    - match: {dependency_type: "all", update_type: "semver:patch"}


### PR DESCRIPTION
I need to cut down on the Github email alerts and in my experience with js libraries when you have this many it can be much less headache to follow the practice of "if it ain't broke (or insecure) don't fix it", at least not in realtime. 

Can we try just patches weekly for a while and see if it is helpful to be less distracted by these commits?